### PR TITLE
Update adaptive walks and add purely neutral walk.

### DIFF
--- a/src/Neighbors.jl
+++ b/src/Neighbors.jl
@@ -60,7 +60,8 @@ function neutral_neighbors(g::Genotype, ls::Landscape)
     i += 1
   end
   neutrals = fits .== f0
-  return nbrs[:,neutrals]
+  neutral_neighbors = nbrs[:,neutrals]
+  return neutral_neighbors[:,sortperm(rand(size(neutral_neighbors)[2]))]
 end
 
 # TODO: Test to make sure this works when there are no fitter neighbors.

--- a/src/Neighbors.jl
+++ b/src/Neighbors.jl
@@ -59,9 +59,8 @@ function neutral_neighbors(g::Genotype, ls::Landscape)
     fits[i] = fitness(nbr, ls)
     i += 1
   end
-  neutrals = fits .== f0
-  neutral_neighbors = nbrs[:,neutrals]
-  return neutral_neighbors[:,sortperm(rand(size(neutral_neighbors)[2]))]
+  neutrals = [j for j = 1:count][fits .== f0] |> shuffle
+  return nbrs[:,neutrals]
 end
 
 # TODO: Test to make sure this works when there are no fitter neighbors.

--- a/src/Walks.jl
+++ b/src/Walks.jl
@@ -1,27 +1,32 @@
 export natural_adaptive_walk, random_adaptive_walk, greedy_adaptive_walk, reluctant_adaptive_walk, neutral_walk
 
+@doc """A record of the path of an adaptive or random walk.
+
+`strategy` - Can be one of :natural, :random, :greedy, :reluctant for now.
+
+`length` - The number of transitions from the original genotype to the ultimate
+optimum. This will be one less than the width of the `history_list` matrix.
+
+`history_list` - Array of genotypes found along the path from the original to
+the optimum. Each genotype is stored in a column.
+
+`history_set` - Dictionary of genotypes found along the path from the original
+to the optimum. Used in plateau search to avoid repeated states
+
+`fitnesses` - Vector of fitnesses of the genotype visited along the path to the
+optimum. The ith fitness corresponds to the ith column in the `history_list`
+matrix.
+"""
 type Walk
-  # Can be one of :natural, :random, :greedy, :reluctant for now.
   strategy::Symbol
-
-  # The number of transitions from the original genotype to the ultimate optimum.
-  # This will be one less than the width of the history_list matrix.
   length::Int64
-
-  # Array of genotypes found along the path from the original to the optimum.
-  # Each genotype is stored in a column.
   history_list::Matrix{Int64}
-
-  # Dictionary of genotypes found along the path from the original to the optimum.
-  # Used in plateau search to avoid repeated states
-  history_set::Dict{Array{Int64,1},Int64}
-
-  # Vector of fitnesses of the genotype visited along the path to the optimum.
-  # The ith fitness corresponds to the ith column in the history_list matrix.
+  history_set::Set{Genotype}
   fitnesses::Vector{Float64}
 end
 
-Walk(s::Symbol, g::Genotype, f::Float64) = Walk(s, 0, reshape(g, (length(g), 1)), Dict{Array{Int64,1},Int64}(g=>1), [f])
+Walk(s::Symbol, g::Genotype, f::Float64) =
+    Walk(s, 0, reshape(g, (length(g), 1)), Set{Genotype}((g,)), [f])
 
 function add_step!(w::Walk, g::Genotype, f::Float64)
   w.length += 1
@@ -32,6 +37,9 @@ end
 function natural_adaptive_walk(g::Genotype, l::Landscape)
 end
 
+@doc """An adaptive walk in which a random, fitter neighbor is chosen at each
+step.
+"""
 function random_adaptive_walk(g::Genotype, l::Landscape)
   g0 = g
   f0 = fitness(g0, l)
@@ -49,6 +57,8 @@ function random_adaptive_walk(g::Genotype, l::Landscape)
   return w
 end
 
+@doc """An adaptive walk in which the fittest neighbor is chosen at each step.
+"""
 function greedy_adaptive_walk(g::Genotype, l::Landscape)
   g0 = g
   f0 = fitness(g0, l)
@@ -66,6 +76,9 @@ function greedy_adaptive_walk(g::Genotype, l::Landscape)
   return w
 end
 
+@doc """An adaptive walk in which the least fit, fitter neighbor is chosen at
+each step.
+"""
 function reluctant_adaptive_walk(g::Genotype, l::Landscape)
   g0 = g
   f0 = fitness(g0, l)
@@ -83,6 +96,14 @@ function reluctant_adaptive_walk(g::Genotype, l::Landscape)
   return w
 end
 
+@doc """A purely neutral walk in which a random, equally fit neighbor is chosen
+at each step. Note that this walk is unlikely to generate a path of length
+greater than one with the `NKLandscape` because it requires exact fitness
+equality.
+
+To avoid cycles, this walk will not revisit genotypes. It uses the
+`history_set` attribute of the `Walk` type to enforce this condition.
+"""
 function neutral_walk(g::Genotype, l::Landscape)
   g0 = g
   f0 = fitness(g0, l)
@@ -94,7 +115,7 @@ function neutral_walk(g::Genotype, l::Landscape)
     end
     i = 1
     g0 = nbrs[:,i]
-    while i < size(nbrs)[2] && g0 in keys(w.history_set)
+    while i < size(nbrs)[2] && g0 in w.history_set
       i += 1
       g0 = nbrs[:,i]
     end
@@ -102,8 +123,9 @@ function neutral_walk(g::Genotype, l::Landscape)
       break
     end
     f0 = fitness(g0, l)
-    w.history_set[g0] = 1
+    push!(w.history_set, g0)
     add_step!(w, g0, f0)
   end
   return w
 end
+

--- a/src/Walks.jl
+++ b/src/Walks.jl
@@ -1,34 +1,38 @@
-export natural_walk, random_walk, greedy_walk, reluctant_walk
+export natural_adaptive_walk, random_adaptive_walk, greedy_adaptive_walk, reluctant_adaptive_walk, neutral_walk
 
 type Walk
   # Can be one of :natural, :random, :greedy, :reluctant for now.
   strategy::Symbol
 
   # The number of transitions from the original genotype to the ultimate optimum.
-  # This will be one less than the width of the history matrix.
+  # This will be one less than the width of the history_list matrix.
   length::Int64
 
-  # Array of genotype found along the path from the original to the optimum.
+  # Array of genotypes found along the path from the original to the optimum.
   # Each genotype is stored in a column.
-  history::Matrix{Int64}
+  history_list::Matrix{Int64}
+
+  # Dictionary of genotypes found along the path from the original to the optimum.
+  # Used in plateau search to avoid repeated states
+  history_set::Dict{Array{Int64,1},Int64}
 
   # Vector of fitnesses of the genotype visited along the path to the optimum.
-  # The ith fitness corresponds to the ith column in the history matrix.
+  # The ith fitness corresponds to the ith column in the history_list matrix.
   fitnesses::Vector{Float64}
 end
 
-Walk(s::Symbol, g::Genotype, f::Float64) = Walk(s, 0, reshape(g, (length(g), 1)), [f])
+Walk(s::Symbol, g::Genotype, f::Float64) = Walk(s, 0, reshape(g, (length(g), 1)), Dict{Array{Int64,1},Int64}(g=>1), [f])
 
 function add_step!(w::Walk, g::Genotype, f::Float64)
   w.length += 1
-  w.history = [w.history g]
+  w.history_list = [w.history_list g]
   w.fitnesses = [w.fitnesses; f]
 end
 
-function natural_walk(g::Genotype, l::Landscape)
+function natural_adaptive_walk(g::Genotype, l::Landscape)
 end
 
-function random_walk(g::Genotype, l::Landscape)
+function random_adaptive_walk(g::Genotype, l::Landscape)
   g0 = g
   f0 = fitness(g0, l)
   w = Walk(:random, g0, f0)
@@ -45,7 +49,7 @@ function random_walk(g::Genotype, l::Landscape)
   return w
 end
 
-function greedy_walk(g::Genotype, l::Landscape)
+function greedy_adaptive_walk(g::Genotype, l::Landscape)
   g0 = g
   f0 = fitness(g0, l)
   w = Walk(:greedy, g0, f0)
@@ -62,7 +66,7 @@ function greedy_walk(g::Genotype, l::Landscape)
   return w
 end
 
-function reluctant_walk(g::Genotype, l::Landscape)
+function reluctant_adaptive_walk(g::Genotype, l::Landscape)
   g0 = g
   f0 = fitness(g0, l)
   w = Walk(:random, g0, f0)
@@ -74,6 +78,31 @@ function reluctant_walk(g::Genotype, l::Landscape)
     g0 = nbrs[:,1]
     f0 = fitness(g0, l)
 
+    add_step!(w, g0, f0)
+  end
+  return w
+end
+
+function neutral_walk(g::Genotype, l::Landscape)
+  g0 = g
+  f0 = fitness(g0, l)
+  w = Walk(:neutral, g0, f0)
+  while true
+    nbrs = neutral_neighbors(g0, l)
+    if length(nbrs) == 0
+      break
+    end
+    i = 1
+    g0 = nbrs[:,i]
+    while i < size(nbrs)[2] && g0 in keys(w.history_set)
+      i += 1
+      g0 = nbrs[:,i]
+    end
+    if i >= size(nbrs)[2]
+      break
+    end
+    f0 = fitness(g0, l)
+    w.history_set[g0] = 1
     add_step!(w, g0, f0)
   end
   return w

--- a/src/selection/proportional.jl
+++ b/src/selection/proportional.jl
@@ -29,6 +29,10 @@ Conduct proportional selection in-place.
 function propsel!(p::Population, ls::Landscape)
   fs = popfits(p, ls)
   fmax = maximum(fs)
+  if fmax == 0
+    # all elements have fitness zero
+    return
+  end
 
   n = popsize(p)
   selected = zeros(Int64, n)

--- a/test/kauffman.jl
+++ b/test/kauffman.jl
@@ -32,7 +32,7 @@ for b = [1, 2]
     for i = 1:LC
       l = NKLandscape(n, k, near=b == 1)
       g = rand(Genotype, l)
-      w = random_walk(g, l)
+      w = random_adaptive_walk(g, l)
       lengths[i] = w.length
       fitnesses[i] = w.fitnesses[end]
     end
@@ -63,7 +63,7 @@ for b = [1, 2]
       l = NKLandscape(n, k, near=b == 1)
       while length(found_opts) <= MAX_FOUND && since_last <= MAX_FAILS
         g = rand(Genotype, l)
-        w = random_walk(g, l)
+        w = random_adaptive_walk(g, l)
         opt = w.history[:,end]
         if !(opt in found_opts)
           push!(found_opts, opt)

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -5,8 +5,16 @@ srand(1)
 
 facts("NKLandscapes.jl") do
   landscapes = [
+    NKLandscape(10, 0),
     NKLandscape(10, 1),
     NKLandscape(10, 2),
+    NKLandscape(10, 3),
+    NKLandscape(10, 4),
+    NKLandscape(10, 5),
+    NKLandscape(10, 6),
+    NKLandscape(10, 7),
+    NKLandscape(10, 8),
+    NKLandscape(10, 9),
     NKqLandscape(10, 1, 2),
     NKpLandscape(10, 1, 0.90),
   ]
@@ -99,8 +107,10 @@ facts("NKLandscapes.jl") do
           function test_neutral_walk(walk_function, genotype, landscape)
             walk = walk_function(genotype, landscape)
             @fact walk.length --> greater_than_or_equal(0)
-            for i = 2:walk.length
-              @fact fitness(walk.history_list[:,i], landscape) --> roughly(fitness(genotype, landscape))
+            f = fitness(genotype, landscape)
+            for i = 1:walk.length
+              f0 = fitness(walk.history_list[:,i], landscape)
+              @fact f0 --> roughly(f)
             end
           end
 

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -8,7 +8,7 @@ facts("NKLandscapes.jl") do
     NKLandscape(10, 1),
     NKLandscape(10, 2),
     NKqLandscape(10, 1, 2),
-    NKpLandscape(10, 1, 0.8),
+    NKpLandscape(10, 1, 0.90),
   ]
 
   for l = landscapes
@@ -36,7 +36,7 @@ facts("NKLandscapes.jl") do
               nbrs = neutral_neighbors(genotype, landscape)
               score = fitness(genotype, landscape)
               @fact size(nbrs)[1] --> landscape.n
-              @fact size(nbrs)[2] --> greater_than(0)
+              @fact size(nbrs)[2] --> greater_than_or_equal(0)
               for j = 1:size(nbrs)[2]
                 @fact fitness(nbrs[:,j], landscape) --> score
               end
@@ -49,7 +49,7 @@ facts("NKLandscapes.jl") do
         context("Fitter neighbors should all be fitter") do
           function test_fitter_neighbors(nbrs, landscape, score)
             @fact size(nbrs)[1] --> landscape.n
-            @fact size(nbrs)[2] --> greater_than(0)
+            @fact size(nbrs)[2] --> greater_than_or_equal(0)
             for j = 1:size(nbrs)[2]
               @fact fitness(nbrs[:,j], landscape) --> greater_than(score)
             end
@@ -67,29 +67,45 @@ facts("NKLandscapes.jl") do
 
         context("Fittest 1 neighbor should be the fittest neighbor") do
           nbrs = fitter_neighbors(g, l)
-          nbr1 = fittest_neighbor(g, l)
-          @fact nbr1 --> nbrs[:,end]
+          if length(nbrs) > 0
+            nbr1 = fittest_neighbor(g, l)
+            @fact nbr1 --> nbrs[:,end]
+          end
         end
 
         context("Adaptive walks") do
           function test_adaptive_walk(walk_function, genotype, landscape)
             walk = walk_function(genotype, landscape)
-            @fact walk.length --> greater_than(0)
+            @fact walk.length --> greater_than_or_equal(0)
             for i = 2:walk.length
-              @fact fitness(walk.history[:,i], landscape) --> greater_than(fitness(genotype, landscape))
+              @fact fitness(walk.history_list[:,i], landscape) --> greater_than(fitness(genotype, landscape))
             end
           end
 
           context("Random adaptive walk should terminate and move uphill") do
-            test_adaptive_walk(random_walk, g, l)
+            test_adaptive_walk(random_adaptive_walk, g, l)
           end
 
           context("Greedy adaptive walk should terminate and move uphill") do
-            test_adaptive_walk(greedy_walk, g, l)
+            test_adaptive_walk(greedy_adaptive_walk, g, l)
           end
 
           context("Reluctant adaptive walk should terminate and move uphill") do
-            test_adaptive_walk(reluctant_walk, g, l)
+            test_adaptive_walk(reluctant_adaptive_walk, g, l)
+          end
+        end
+
+        context("Neutral walks") do
+          function test_neutral_walk(walk_function, genotype, landscape)
+            walk = walk_function(genotype, landscape)
+            @fact walk.length --> greater_than_or_equal(0)
+            for i = 2:walk.length
+              @fact fitness(walk.history_list[:,i], landscape) --> roughly(fitness(genotype, landscape))
+            end
+          end
+
+          context("Neutral walk should terminate and move sideways") do
+            test_neutral_walk(neutral_walk, g, l)
           end
         end
       end


### PR DESCRIPTION
The following changes have been made:
- Renamed random_walk to random_adaptive_walk, greedy_walk to greedy_adaptive_walk, and reluctant_walk to reluctant_adaptive_walk to make it clear that all move towards increasing fitness.
- Modified neutral_neighbors to return neighbors in a random order.
- Wrote  neutral_walk  to produce a walk that explores the neutral network of the starting genotype.
- Added history_set as an attribute of a walk which is used to prevent repeated genotypes on a neutral walk.
- Renamed the history attribute of a walk to history_list.
- Found that the neutral_neighbors and fitter_neighbors may be empty, and that neutral_walk and greedy_walk may produce walks of length 0 (only the starting genotype). Modified test/unit.jl so that these situations do not create errors.
