### PR TITLE
Convert fastfunc tests to FactCheck and include in unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ published results.
 The unit tests may be run with `./runtests.sh unit`. The functional tests may
 be run with `./runtests.sh SUITE` where `SUITE` is one of the following:
 
-  * fastfunc - some fast-running functional tests
+  * fastfunc - some fast-running functional tests, these are run automatically
+    with the unit tests
   * `kauffman` - experiments from [1]
   * `nowak` - experiments from [2]
 

--- a/src/selection/moran.jl
+++ b/src/selection/moran.jl
@@ -4,7 +4,7 @@ export moransel, moransel!
 
 function moransel(p::Population, ls::Landscape, iters::Int64)
   np = copy(p)
-  moransel!(np, ls)
+  moransel!(np, ls, iters)
   return np
 end
 

--- a/src/selection/tournament.jl
+++ b/src/selection/tournament.jl
@@ -9,7 +9,7 @@ population. For now, we assume `p=1`, so the best individual in
 the tournament is selected as a member of the new population.
 Each tournament involves `k` members of the population.
 
-Note that sampling is done without replacement, so even if
+Note that sampling is done with replacement, so even if
 `k` is equal to the population size, there is no guarantee
 that every individual will participate in each tournament.
 

--- a/test/fastfunc.jl
+++ b/test/fastfunc.jl
@@ -88,6 +88,24 @@ facts("NKLandscapes.jl fast functional tests") do
     @fact oldmean --> less_than(newmean) "Expected greater mean fitness after selection"
   end
 
+  context("NK.tournsel(...)") do
+    srand(0)
+    newpop = NK.tournsel(pop, ls, 8)
+
+    counts = zeros(Int64, 8)
+    for i = 1:8
+      for j = 1:8
+        if newpop[:,i] == pop[:,j]
+          counts[j] += 1
+        end
+      end
+    end
+    @fact any(c -> c > 1, counts) --> true "Expected a different population after selection"
+    oldmean = mean(fits)
+    newmean = mean(NK.popfits(newpop, ls))
+    @fact oldmean --> less_than(newmean) "Expected greater mean fitness after selection"
+  end
+
   context("NK.moransel(...)") do
     srand(0)
     newpop = NK.moransel(pop, ls, 8)

--- a/test/fastfunc.jl
+++ b/test/fastfunc.jl
@@ -88,6 +88,24 @@ facts("NKLandscapes.jl fast functional tests") do
     @fact oldmean --> less_than(newmean) "Expected greater mean fitness after selection"
   end
 
+  context("NK.moransel(...)") do
+    srand(0)
+    newpop = NK.moransel(pop, ls, 8)
+
+    counts = zeros(Int64, 8)
+    for i = 1:8
+      for j = 1:8
+        if newpop[:,i] == pop[:,j]
+          counts[j] += 1
+        end
+      end
+    end
+    @fact any(c -> c > 1, counts) --> true "Expected a different population after selection"
+    oldmean = mean(fits)
+    newmean = mean(NK.popfits(newpop, ls))
+    @fact oldmean --> less_than(newmean) "Expected greater mean fitness after selection"
+  end
+
   context("NK.bwmutate(...)") do
     srand(0)
     trials = 1000

--- a/test/fastfunc.jl
+++ b/test/fastfunc.jl
@@ -1,5 +1,6 @@
 import NKLandscapes
 const NK = NKLandscapes
+using FactCheck
 
 n = 3
 k = 1
@@ -48,66 +49,71 @@ fits = [
   (0.4 + 0.1 + 0.3) / 3.0,
 ]
 
-# NK.fitness(...)
+facts("NKLandscapes.jl fast functional tests") do
 
-function testfitness(g, f0)
-  f1 = NK.fitness(g, ls)
-  @assert isapprox(f0, f1) "Expected $(f0), found $(f1), for $(g)"
-end
+  context("NK.fitness(...)") do
+    function testfitness(g, f0)
+      f1 = NK.fitness(g, ls)
+      @fact f0 --> roughly(f1) "Expected $(f0), found $(f1), for $(g)"
+    end
 
-for i = 1:8
-  testfitness(pop[:,i], fits[i])
-end
-
-# NK.popfits(...)
-
-fitsa = NK.popfits(pop, ls)
-
-for i = 1:8
-  @assert isapprox(fits[i], fitsa[i]) "Expected $(fits[i]), found $(fitsa[i]) for $(i)th"
-end
-
-# NK.propsel(...)
-
-srand(0)
-newpop = NK.propsel(pop, ls)
-
-counts = zeros(Int64, 8)
-for i = 1:8
-  for j = 1:8
-    if newpop[:,i] == pop[:,j]
-      counts[j] += 1
+    for i = 1:8
+      testfitness(pop[:,i], fits[i])
     end
   end
-end
-@assert any(c -> c > 1, counts) "Expected a different population after selection"
-@assert mean(fits) < mean(NK.popfits(newpop, ls)) "Expected greater mean fitness after selection"
 
-# NK.bwmutate(...)
+  context("NK.popfits(...)") do
+    fitsa = NK.popfits(pop, ls)
 
-srand(0)
-trials = 1000
-mutprob = 0.1
-total = 0.0
-for _ = 1:trials
-  newpop = NK.bwmutate(pop, ls, mutprob)
-  total += (pop .!= newpop) |> sum
-end
-meanmuts = total / (trials * length(pop))
-@assert isapprox(mutprob, meanmuts, atol=mutprob / 10) "Expected $(mutprob) mutation rate, found $(meanmuts)"
-
-# NK.bsmutate(...)
-
-srand(0)
-newpop = NK.bsmutate(pop, ls, 1.0)
-
-for i = 1:8
-  count = 0
-  for j = 1:ls.n
-    if newpop[j,i] != pop[j,i]
-      count += 1
+    for i = 1:8
+      @fact fits[i] --> roughly(fitsa[i]) "Expected $(fits[i]), found $(fitsa[i]) for $(i)th"
     end
   end
-  @assert count == 1 "Expected 1 difference in $(pop[:,i]), $(newpop[:,i]), found $(count)"
+
+  context("NK.propsel(...)") do
+    srand(0)
+    newpop = NK.propsel(pop, ls)
+
+    counts = zeros(Int64, 8)
+    for i = 1:8
+      for j = 1:8
+        if newpop[:,i] == pop[:,j]
+          counts[j] += 1
+        end
+      end
+    end
+    @fact any(c -> c > 1, counts) --> true "Expected a different population after selection"
+    oldmean = mean(fits)
+    newmean = mean(NK.popfits(newpop, ls))
+    @fact oldmean --> less_than(newmean) "Expected greater mean fitness after selection"
+  end
+
+  context("NK.bwmutate(...)") do
+    srand(0)
+    trials = 1000
+    mutprob = 0.1
+    total = 0.0
+    for _ = 1:trials
+      newpop = NK.bwmutate(pop, ls, mutprob)
+      total += (pop .!= newpop) |> sum
+    end
+    meanmuts = total / (trials * length(pop))
+    @fact mutprob --> roughly(meanmuts; atol=mutprob / 10) "Expected $(mutprob) mutrate, found $(meanmuts)"
+  end
+
+  context("NK.bsmutate(...)") do
+    srand(0)
+    newpop = NK.bsmutate(pop, ls, 1.0)
+
+    for i = 1:8
+      count = 0
+      for j = 1:ls.n
+        if newpop[j,i] != pop[j,i]
+          count += 1
+        end
+      end
+      @fact count --> 1 "Expected 1 difference in $(pop[:,i]), $(newpop[:,i]), found $(count)"
+    end
+  end
 end
 

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -196,3 +196,6 @@ facts("NKLandscapes.jl") do
     end
   end
 end
+
+include("fastfunc.jl")
+

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -39,6 +39,11 @@ facts("NKLandscapes.jl") do
           test_neighbors(g, l)
         end
 
+        context("Random neighbor should be a neighbor") do
+          g0 = random_neighbor(g, l)
+          @fact (g - g0) |> sum |> abs --> 1
+        end
+
         if typeof(l) != NKLandscape
           context("Neutral neighbors should have the same fitness") do
             function test_neutral_neighbors(genotype, landscape)

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -15,6 +15,7 @@ facts("NKLandscapes.jl") do
     NKLandscape(10, 7),
     NKLandscape(10, 8),
     NKLandscape(10, 9),
+    NKLandscape(10, 4; near=true),
     NKqLandscape(10, 1, 2),
     NKpLandscape(10, 1, 0.90),
   ]


### PR DESCRIPTION
We should be able to improve our test coverage a bit, and ensure that the fast functional tests are actually run, by converting them to use FactCheck and running them whenever the unit tests are run.

Also add some tests for areas that aren't very well covered.
